### PR TITLE
Add primary key

### DIFF
--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS `user_tokens` (
 	`token` varchar(40) NOT NULL COMMENT 'The generated unique token',
 	`uid` int(11) NOT NULL COMMENT 'The User ID',
 	`requested` varchar(20) NOT NULL COMMENT 'The date when token was created'
+	PRIMARY KEY (`token`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 --


### PR DESCRIPTION
Setting the token to a primary key has two benefits: (1) it requires the token to be unique - as it would cause unintended consquences if two users had the same token; and (2) it enables the table to be edited using tools such as PHPMyAdmin or other databse tool.